### PR TITLE
Rownames should be populated in the GRanges.Otherwise final file does…

### DIFF
--- a/bin/post_peak_calling_processing.r
+++ b/bin/post_peak_calling_processing.r
@@ -59,10 +59,16 @@ anno <- plyr::adply(unique(annotation$gene_id),
                     function(x) {
                         aux <- reduce(annotation[annotation$gene_id == x])
                         aux$symbol <- unique(annotation[annotation$gene_id == x]$gene_name)
-                        as.data.frame(aux)
+                        aux$gene_id <- x
+                        df <- as.data.frame(aux)
+                        # For some ENSG genes, there is a small gap between transcripts
+                        df$start <- min(df$start)
+                        df$end <- max(df$end)
+                        df
                     }, .id = NULL, .parallel = TRUE)
 
-annoData <- makeGRangesFromDataFrame(anno, keep.extra.columns = T)
+annoData <- unique(makeGRangesFromDataFrame(anno, keep.extra.columns = T))
+names(annoData) <- annoData$gene_id
 
 # Read in blacklist file and convert into range object
 if (Blacklist != "No-filtering") {


### PR DESCRIPTION
@ewels There was a small bug in the code. I need to populate the names in the `granges`, the report did not show, but I transformed the data later and there was this difference.

Also, some genes has some non-overlapping regions, so reduce will produce one than one region. We kept the old procedure to get the min and max and the remove the duplicated, which will produce the same result as before the improvement.