### PR TITLE
Tidying + getting the tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 sudo: required
 language: java
 jdk: openjdk8
-services:
-  - docker
+services: docker
 
-
-before_install:
-  # Pull the docker image first so the test doesn't wait for this
-- docker pull nfcore/chipseq:latest
+before_install: docker pull nfcore/chipseq:latest
 
 install:
   # Install Nextflow
@@ -28,9 +24,9 @@ env:
   - ''
 
 script:
-    # Lint the pipeline code
-    - "nf-core lint ${TRAVIS_BUILD_DIR}"
-    # Run, build reference genome
-    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
-    # Basic run with supplied reference
-    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --genome EF4
+  # Lint the pipeline code
+  - "nf-core lint ${TRAVIS_BUILD_DIR}"
+  # Run, build reference genome
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
+  # Basic run with supplied reference
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --genome EF4

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
     # Lint the pipeline code
     - "nf-core lint ${TRAVIS_BUILD_DIR}"
     # Run, build reference genome
-    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --saveReference
+    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
     # Basic run with supplied reference
-    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --bwa_index ${TRAVIS_BUILD_DIR}/tests/results/reference_genome/BWAIndex/
+    - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --genome EF4

--- a/conf/base.config
+++ b/conf/base.config
@@ -25,14 +25,11 @@ process {
   time = { check_max( 2.h * task.attempt, 'time' ) }
   container = params.container
 
-  errorStrategy = { task.exitStatus == 143 ? 'retry' : 'finish' }
+  errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'terminate' }
   maxRetries = 1
   maxErrors = '-1'
 
   // Environment modules and resource requirements
-  $fastqc {
-    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
-  }
   $trim_galore {
     cpus = { check_max( 2 * task.attempt, 'cpus' ) }
     memory = { check_max( 16.GB * task.attempt, 'memory' ) }
@@ -86,11 +83,9 @@ process {
   }
   $get_software_versions {
     memory = { check_max( 2.GB * task.attempt, 'memory' ) }
-    executor = 'local'
     errorStrategy = 'ignore'
   }
   $multiqc {
     memory = { check_max( 2.GB * task.attempt, 'memory' ) }
-    executor = 'local'
   }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -8,7 +8,6 @@
  */
 
 params {
-  genome = 'EF4'
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h

--- a/main.nf
+++ b/main.nf
@@ -99,6 +99,7 @@ if (params.help){
 // Configurable variables
 params.name = false
 params.project = false
+params.genome = false
 params.genomes = false
 params.fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
 params.bwa_index = params.genome ? params.genomes[ params.genome ].bwa ?: false : false
@@ -195,11 +196,6 @@ def REF_macs = false
 def REF_ngsplot = false
 if (params.genome == 'GRCh37'){ REF_macs = 'hs'; REF_ngsplot = 'hg19' }
 else if (params.genome == 'GRCm38'){ REF_macs = 'mm'; REF_ngsplot = 'mm10' }
-else if (params.genome == false){
-    log.warn "No reference supplied for MACS, ngs_plot and annotation. Use '--genome GRCh37' or '--genome GRCm38' to run MACS, ngs_plot and annotation."
-} else {
-    log.warn "Reference '${params.genome}' not supported by MACS, ngs_plot and annotation (only GRCh37 and GRCm38)."
-}
 
 
 log.info """=======================================================
@@ -281,6 +277,17 @@ if( workflow.profile == 'standard'){
     }
 }
 
+// Show a big warning message if we're not running MACS
+if (!REF_macs){
+    def warnstring = params.genome ? "Reference '${params.genome}' not supported by" : 'No reference supplied for'
+    log.warn "=======================================================\n" +
+             "  WARNING! $warnstring MACS, ngs_plot\n" +
+             "  and annotation. Steps for MACS, ngs_plot and annotation\n" +
+             "  will be skipped. Use '--genome GRCh37' or '--genome GRCm38'\n" +
+             "  to run these steps.\n" +
+             "==============================================================="
+}
+
 
 /*
  * PREPROCESSING - Build BWA index
@@ -299,8 +306,8 @@ if(!params.bwa_index && fasta){
 
         script:
         """
-        mkdir BWAIndex
         bwa index -a bwtsw $fasta
+        mkdir BWAIndex && mv ${fasta}* BWAIndex
         """
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,8 +61,8 @@ profiles {
   }
   test {
     includeConfig 'conf/base.config'
-    includeConfig 'conf/igenomes.config'
     includeConfig 'conf/test.config'
+    includeConfig 'conf/igenomes.config'
   }
   aws {
     includeConfig 'conf/base.config'


### PR DESCRIPTION
* Removed `params.genome` so that the tests build the reference genome
* Refactored `.travis.yml` to specify `--genome` in the second test to use an existing ref
* Fixed a bug in the process that builds BWA references
* Made the not-running-MACS2 warning message much bigger, and put it after the initial log
* Fixed a minor bug where `params.genome` was throwing a warning as it had no default value
* Stopped ignoring so many processes if they fail
* Changed the pipeline error strategy to `terminate` instead of `finish`

Note - tests are still failing because they're timing out on the `deeptools` process, because it's slow. We need to change the test data to fix this. See #18.
