### PR TITLE
Fix #28. Missing default configuration for genome in standard profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ profiles {
 
   standard {
     includeConfig 'conf/base.config'
+    includeConfig 'conf/igenomes.config'
   }
   conda { process.conda = "$baseDir/environment.yml" }
   docker { docker.enabled = true }


### PR DESCRIPTION
This will fix issue #28. But `-profile standard,docker` still required