### PR TITLE
Set default params.readPaths

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
   container = 'nfcore/chipseq:latest' // Container slug. Stable releases should specify release tag!
 
   reads = "data/*{1,2}*.fastq.gz"
+  readPaths = false
   macsconfig = "data/macsconfig"
   multiqc_config = "$baseDir/conf/multiqc_config.yaml"
   extendReadsLen = 100


### PR DESCRIPTION
We added the new `params.readPaths` for the test config, however it doesn't have a default value set so we get a warning from nextflow.