### PR TITLE
Filtering macs2 files without peaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [[#128](https://github.com/nf-core/chipseq/issues/128)] - Filter files with no peaks to avoid errors in downstream processes
 - [[#220](https://github.com/nf-core/chipseq/issues/220)] - Fix `phantompeakqualtools` protection stack overflow error
 - [[#233](https://github.com/nf-core/chipseq/issues/233)] - Add `chromap` to the available aligners
 - Update pipeline template to nf-core/tools `2.2`

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -263,7 +263,7 @@ workflow CHIPSEQ {
     //
     FILTER_BAM_BAMTOOLS (
         MARK_DUPLICATES_PICARD.out.bam.join(MARK_DUPLICATES_PICARD.out.bai, by: [0]),
-        PREPARE_GENOME.out.filtered_bed,
+        PREPARE_GENOME.out.filtered_bed.first(),
 
         ch_bamtools_filter_se_config,
         ch_bamtools_filter_pe_config
@@ -405,10 +405,22 @@ workflow CHIPSEQ {
             ch_ip_control_bam,
             params.macs_gsize
         )
+
         ch_versions = ch_versions.mix(MACS2_CALLPEAK.out.versions.first())
 
+        //
+        // Filter for MACS2 files without peaks
+        //
+        // [[id:SPT5_T15_REP1, single_end:false, antibody:SPT5, control:SPT5_INPUT_REP1], /home/kadomu/nxf_scratch/02/91c628910c3014b2267e2bcff1a82d/SPT5_T15_REP1_peaks.broadPeak]
+        MACS2_CALLPEAK
+            .out
+            .peak
+            .filter { meta, peaks -> peaks.size() > 0 }
+            .set { ch_macs2_peaks }
+
         ch_ip_control_bam
-            .join(MACS2_CALLPEAK.out.peak, by: [0])
+            //.join(MACS2_CALLPEAK.out.peak, by: [0])
+            .join(ch_macs2_peaks, by: [0])
             .map { it -> [ it[0], it[1], it[3] ] }
             .set { ch_ip_peak }
         FRIP_SCORE (
@@ -431,12 +443,14 @@ workflow CHIPSEQ {
 
         if (!params.skip_peak_annotation && !params.skip_peak_qc) {
             PLOT_MACS2_QC (
-                MACS2_CALLPEAK.out.peak.collect{it[1]}
+                // MACS2_CALLPEAK.out.peak.collect{it[1]}
+                ch_macs2_peaks.collect{it[1]}
             )
             ch_versions = ch_versions.mix(PLOT_MACS2_QC.out.versions)
 
             HOMER_ANNOTATEPEAKS_MACS2 (
-                MACS2_CALLPEAK.out.peak,
+                // MACS2_CALLPEAK.out.peak
+                ch_macs2_peaks,
                 PREPARE_GENOME.out.fasta,
                 PREPARE_GENOME.out.gtf
             )
@@ -457,9 +471,11 @@ workflow CHIPSEQ {
         if (!params.skip_consensus_peaks) {
             // Create channel: [ meta , [ peaks ] ]
             // Where meta = [ id:antibody, multiple_groups:true/false, replicates_exist:true/false ]
-            MACS2_CALLPEAK
-                .out
-                .peak
+
+            // MACS2_CALLPEAK
+            //     .out
+            //     .peak
+            ch_macs2_peaks
                 .map { meta, peak -> [ meta.antibody, meta.id.split('_')[0..-2].join('_'), peak ] }
                 .groupTuple()
                 .map {
@@ -538,7 +554,8 @@ workflow CHIPSEQ {
                 IGV (
                     PREPARE_GENOME.out.fasta,
                     UCSC_BEDGRAPHTOBIGWIG.out.bigwig.collect{it[1]}.ifEmpty([]),
-                    MACS2_CALLPEAK.out.peak.collect{it[1]}.ifEmpty([]),
+                    // MACS2_CALLPEAK.out.peak.collect{it[1]}.ifEmpty([]),
+                    ch_macs2_peaks.collect{it[1]}.ifEmpty([]),
                     MACS2_CONSENSUS.out.bed.collect{it[1]}.ifEmpty([]),
                     "bwa/mergedLibrary/bigwig",
                     { ["bwa/mergedLibrary/macs2",


### PR DESCRIPTION
As explained in #128 when macs2 files have any peak inside an exception is raised.

Closes #128 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] `CHANGELOG.md` is updated
