### PR TITLE
Define DSL1 explicitly, as Nextflow made DSL2 default

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -8,6 +8,7 @@
  https://github.com/nf-core/chipseq
 ----------------------------------------------------------------------------------------
 */
+nextflow.enable.dsl=1
 
 def helpMessage() {
     log.info nfcoreHeader()


### PR DESCRIPTION
Signed-off-by: Lehmann_Fabian <fabian.lehmann@informatik.hu-berlin.de>

Cannot start DSL1 workflows with the newest Nextflow version. So I had to define the DSL version explicitly.
The Dev-Branch is already on DSL2, so this should be merged directly into the master to avoid problems with the stable version.

# nf-core/chipseq pull request

Many thanks for contributing to nf-core/chipseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/chipseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/chipseq)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/chipseq/tree/master/.github/CONTRIBUTING.md)
