### PR TITLE
Fixes

### DIFF
--- a/assets/multiqc/deseq2_clustering_header.txt
+++ b/assets/multiqc/deseq2_clustering_header.txt
@@ -3,7 +3,7 @@
 #description: "is generated from clustering the Euclidean distances between
 #              <a href='https://bioconductor.org/packages/release/bioc/html/DESeq2.html' target='_blank'>DESeq2</a>
 #              rlog values for each sample
-#              in the <a href='https://github.com/nf-core/rnaseq/blob/master/bin/deseq2_qc.r'><code>deseq2_qc.r</code></a> script."
+#              in the <a href='https://github.com/nf-core/chipseq/blob/master/bin/deseq2_qc.r'><code>deseq2_qc.r</code></a> script."
 #plot_type: 'heatmap'
 #anchor: 'deseq2_clustering'
 #pconfig:

--- a/assets/multiqc/deseq2_pca_header.txt
+++ b/assets/multiqc/deseq2_pca_header.txt
@@ -2,7 +2,7 @@
 #section_name: 'MERGED LIB: DESeq2 PCA plot'
 #description: "PCA plot between samples in the experiment.
 #              These values are calculated using <a href='https://bioconductor.org/packages/release/bioc/html/DESeq2.html'>DESeq2</a>
-#              in the <a href='https://github.com/nf-core/atacseq/blob/master/bin/deseq2_qc.r'><code>deseq2_qc.r</code></a> script."
+#              in the <a href='https://github.com/nf-core/chipseq/blob/master/bin/deseq2_qc.r'><code>deseq2_qc.r</code></a> script."
 #plot_type: 'scatter'
 #anchor: 'deseq2_pca'
 #pconfig:

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -511,8 +511,8 @@ if (params.macs_gsize) {
                 '--keep-dup all',
                 params.narrow_peak      ? '' : "--broad --broad-cutoff ${params.broad_cutoff}",
                 params.save_macs_pileup ? '--bdg --SPMR' : '',
-                params.macs_fdr         ? "--pvalue ${params.macs_pvalue}" : '',
-                params.macs_pvalue      ? "--qvalue ${params.macs_fdr}" : ''
+                params.macs_fdr         ? "--qvalue ${params.macs_fdr}" : '',
+                params.macs_pvalue      ? "--pvalue ${params.macs_pvalue}" : ''
             ].join(' ').trim()
             publishDir = [
                 path: { [
@@ -549,21 +549,8 @@ if (params.macs_gsize) {
         }
     }
 
-    if (!params.skip_peak_annotation && !params.skip_peak_qc) {
+    if (!params.skip_peak_annotation) {
         process {
-            withName: 'PLOT_MACS2_QC' {
-                ext.args   = '-o ./ -p macs2_peak'
-                publishDir = [
-                    path: { [
-                        "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
-                        params.narrow_peak? '/narrowPeak' : '/broadPeak',
-                        '/qc'
-                    ].join('') },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
-
             withName: 'HOMER_ANNOTATEPEAKS_MACS2' {
                 ext.args   = '-gid'
                 // ext.prefix = 'peaks'
@@ -576,18 +563,35 @@ if (params.macs_gsize) {
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
             }
+        }
 
-            withName: 'PLOT_HOMER_ANNOTATEPEAKS' {
-                ext.args   = '-o ./ -p macs2_annotatePeaks'
-                publishDir = [
-                    path: { [
-                        "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
-                        params.narrow_peak? '/narrowPeak' : '/broadPeak',
-                        '/qc'
+        if (!params.skip_peak_qc) {
+            process {
+                withName: 'PLOT_MACS2_QC' {
+                    ext.args   = '-o ./ -p macs2_peak'
+                    publishDir = [
+                        path: { [
+                            "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
+                            params.narrow_peak? '/narrowPeak' : '/broadPeak',
+                            '/qc'
                         ].join('') },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
+                        mode: params.publish_dir_mode,
+                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ]
+                }
+
+                withName: 'PLOT_HOMER_ANNOTATEPEAKS' {
+                    ext.args   = '-o ./ -p macs2_annotatePeaks'
+                    publishDir = [
+                        path: { [
+                            "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
+                            params.narrow_peak? '/narrowPeak' : '/broadPeak',
+                            '/qc'
+                            ].join('') },
+                        mode: params.publish_dir_mode,
+                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ]
+                }
             }
         }
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -624,59 +624,59 @@ if (params.macs_gsize) {
                 ]
             }
         }
-    }
 
-    if (!params.skip_peak_annotation) {
-        process {
-            withName: 'HOMER_ANNOTATEPEAKS_CONSENSUS' {
-                ext.args   = '-gid'
-                ext.prefix = 'consensus_peaks'
-                publishDir = [
-                    path: { [
-                        "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
-                        params.narrow_peak? '/narrowPeak' : '/broadPeak',
-                        '/consensus'
-                        ].join('') },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
-        }
-    }
-
-    if (!params.skip_deseq2_qc) {
-        process {
-            withName: DESEQ2_QC {
-                ext.args   = [
-                    '--id_col 1',
-                    '--sample_suffix \'.mLb.clN.sorted.bam\'',
-                    '--count_col 7',
-                    params.deseq2_vst ? '--vst TRUE' : ''
-                ].join(' ').trim()
-                publishDir = [
-                    path: { [
-                        "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
-                        params.narrow_peak? '/narrowPeak' : '/broadPeak',
-                        '/consensus/deseq2'
-                        ].join('') },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
-        }
-    }
-
-    if (!params.skip_igv) {
-        process {
-            withName: 'IGV' {
-                publishDir = [
+        if (!params.skip_peak_annotation) {
+            process {
+                withName: 'HOMER_ANNOTATEPEAKS_CONSENSUS' {
+                    ext.args   = '-gid'
+                    ext.prefix = 'consensus_peaks'
+                    publishDir = [
                         path: { [
-                            "${params.outdir}/igv",
-                            params.narrow_peak? '/narrowPeak' : '/broadPeak'
+                            "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
+                            params.narrow_peak? '/narrowPeak' : '/broadPeak',
+                            '/consensus'
                             ].join('') },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
+                    ]
+                }
+            }
+        }
+
+        if (!params.skip_deseq2_qc) {
+            process {
+                withName: DESEQ2_QC {
+                    ext.args   = [
+                        '--id_col 1',
+                        '--sample_suffix \'.mLb.clN.sorted.bam\'',
+                        '--count_col 7',
+                        params.deseq2_vst ? '--vst TRUE' : ''
+                    ].join(' ').trim()
+                    publishDir = [
+                        path: { [
+                            "${params.outdir}/${params.aligner}/mergedLibrary/macs2",
+                            params.narrow_peak? '/narrowPeak' : '/broadPeak',
+                            '/consensus/deseq2'
+                            ].join('') },
+                        mode: params.publish_dir_mode,
+                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ]
+                }
+            }
+        }
+
+        if (!params.skip_igv) {
+            process {
+                withName: 'IGV' {
+                    publishDir = [
+                            path: { [
+                                "${params.outdir}/igv",
+                                params.narrow_peak? '/narrowPeak' : '/broadPeak'
+                                ].join('') },
+                            mode: params.publish_dir_mode,
+                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ]
+                }
             }
         }
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -598,6 +598,7 @@ if (params.macs_gsize) {
     if (!params.skip_consensus_peaks) {
         process {
             withName: 'MACS2_CONSENSUS' {
+                ext.when   = { meta.multiple_groups || meta.replicates_exist }
                 ext.prefix = { "${meta.id}.consensus_peaks" }
                 publishDir = [
                     path: { [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -489,10 +489,11 @@ if (!params.skip_plot_profile) {
 if (!params.skip_plot_fingerprint) {
     process {
         withName: 'DEEPTOOLS_PLOTFINGERPRINT' {
-            ext.args   = [
+            ext.args   = { [
                 '--skipZeros',
-                "--numberOfSamples $params.fingerprint_bins"
-            ].join(' ').trim()
+                "--numberOfSamples $params.fingerprint_bins",
+                "--labels $meta.ip $meta.control"
+            ].join(' ').trim() }
             ext.prefix = { "${meta.id}.mLb.clN" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/mergedLibrary/deeptools/plotFingerprint" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -310,7 +310,6 @@ process {
     }
 
     withName: '.*:MARK_DUPLICATES_PICARD:SAMTOOLS_INDEX' {
-        ext.prefix = { "${meta.id}.mkD.sorted" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/mergedLibrary" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,12 +23,16 @@ params {
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/chipseq/samplesheet/v2.0/samplesheet_test.csv'
 
     // Genome references
-    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genome.fa'
-    gtf   = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genes.gtf'
+    genome = 'hg19'
+    // fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genome.fa'
+    // gtf   = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genes.gtf'
 
     // Not mandatory but permits the pipeline to run through peak-calling steps
     macs_gsize = 1.2e7
 
     // For speed to avoid CI time-out
     fingerprint_bins = 100
+
+    // Avoid preseq errors with test data
+    skip_preseq = true
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,9 +23,8 @@ params {
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/chipseq/samplesheet/v2.0/samplesheet_test.csv'
 
     // Genome references
-    genome = 'hg19'
-    // fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genome.fa'
-    // gtf   = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genes.gtf'
+    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genome.fa'
+    gtf   = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genes.gtf'
 
     // Not mandatory but permits the pipeline to run through peak-calling steps
     macs_gsize = 1.2e7

--- a/modules/local/deseq2_qc.nf
+++ b/modules/local/deseq2_qc.nf
@@ -24,7 +24,7 @@ process DESEQ2_QC {
     path "versions.yml"         , emit: versions
 
     script:
-    if (meta.multiple_groups || meta.replicates_exist) {
+    if (meta.multiple_groups && meta.replicates_exist) {
         def args      = task.ext.args ?: ''
         def peak_type = params.narrow_peak ? 'narrowPeak' : 'broadPeak'
         def antibody  = meta.antibody

--- a/modules/local/macs2_consensus.nf
+++ b/modules/local/macs2_consensus.nf
@@ -22,7 +22,7 @@ process MACS2_CONSENSUS {
     path "versions.yml"                     , emit: versions
 
     when:
-    (meta.multiple_groups || meta.replicates_exist)
+    task.ext.when == null || task.ext.when
 
     script: // This script is bundled with the pipeline, in nf-core/chipseq/bin/
 

--- a/modules/local/multiqc_custom_peaks.nf
+++ b/modules/local/multiqc_custom_peaks.nf
@@ -12,7 +12,7 @@ process MULTIQC_CUSTOM_PEAKS {
 
     output:
     tuple val(meta), path("*.peak_count_mqc.tsv"), emit: count
-    tuple val(meta), path("*.FRiP_mqc.tsv"), emit: frip
+    tuple val(meta), path("*.FRiP_mqc.tsv")      , emit: frip
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/multiqc_custom_phantompeakqualtools.nf
+++ b/modules/local/multiqc_custom_phantompeakqualtools.nf
@@ -11,8 +11,8 @@ process MULTIQC_CUSTOM_PHANTOMPEAKQUALTOOLS {
     path correlation_header
 
     output:
-    tuple val(meta), path("*.spp_nsc_mqc.tsv"), emit: nsc
-    tuple val(meta), path("*.spp_rsc_mqc.tsv"), emit: rsc
+    tuple val(meta), path("*.spp_nsc_mqc.tsv")        , emit: nsc
+    tuple val(meta), path("*.spp_rsc_mqc.tsv")        , emit: rsc
     tuple val(meta), path("*.spp_correlation_mqc.tsv"), emit: correlation
 
     script:

--- a/modules/local/plot_homer_annotatepeaks.nf
+++ b/modules/local/plot_homer_annotatepeaks.nf
@@ -12,9 +12,9 @@ process PLOT_HOMER_ANNOTATEPEAKS {
     val suffix
 
     output:
-    path '*.txt', emit: txt
-    path '*.pdf', emit: pdf
-    path '*.tsv', emit: tsv
+    path '*.txt'       , emit: txt
+    path '*.pdf'       , emit: pdf
+    path '*.tsv'       , emit: tsv
     path "versions.yml", emit: versions
 
     script: // This script is bundled with the pipeline, in nf-core/chipseq/bin/

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": ["outdir"],
             "properties": {
                 "input": {
                     "type": "string",

--- a/subworkflows/local/filter_bam_bamtools.nf
+++ b/subworkflows/local/filter_bam_bamtools.nf
@@ -14,7 +14,6 @@ workflow FILTER_BAM_BAMTOOLS {
     bamtools_filter_pe_config //    file: BAMtools filter JSON config file for PE data
 
     main:
-
     ch_versions = Channel.empty()
 
     BAM_FILTER(ch_bam_bai, ch_bed, bamtools_filter_se_config, bamtools_filter_pe_config)

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -45,16 +45,9 @@ workflow PREPARE_GENOME {
 
     // Make fasta file available if reference saved or IGV is run
     if (params.save_reference || !params.skip_igv) {
-        // log.info "test\n===============culo\n===============culo\n===============culo\n===============culo\n===============culo\n"
         file("${params.outdir}/genome/").mkdirs()
         ch_fasta.copyTo("${params.outdir}/genome/")
     }
-    // else {
-    //     log.info "pedo\n===============pedo\n===============pedo\n================pedo\n===============pedo\n===============pedo\n"
-    // }
-    // ch_fasta.subscribe {
-    //     it.copyTo("${params.outdir}/genome/")
-    // }
 
     //
     // Uncompress GTF annotation file or create from GFF3 if required

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -43,6 +43,19 @@ workflow PREPARE_GENOME {
         ch_fasta = file(params.fasta)
     }
 
+    // Make fasta file available if reference saved or IGV is run
+    if (params.save_reference || !params.skip_igv) {
+        // log.info "test\n===============culo\n===============culo\n===============culo\n===============culo\n===============culo\n"
+        file("${params.outdir}/genome/").mkdirs()
+        ch_fasta.copyTo("${params.outdir}/genome/")
+    }
+    // else {
+    //     log.info "pedo\n===============pedo\n===============pedo\n================pedo\n===============pedo\n===============pedo\n"
+    // }
+    // ch_fasta.subscribe {
+    //     it.copyTo("${params.outdir}/genome/")
+    // }
+
     //
     // Uncompress GTF annotation file or create from GFF3 if required
     //

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -279,7 +279,7 @@ workflow CHIPSEQ {
             FILTER_BAM_BAMTOOLS.out.bam,
             PREPARE_GENOME.out.fasta
         )
-        ch_picardcollectmultiplemetrics_multiqc = MARK_DUPLICATES_PICARD.out.metrics
+        ch_picardcollectmultiplemetrics_multiqc = PICARD_COLLECTMULTIPLEMETRICS.out.metrics
         ch_versions = ch_versions.mix(PICARD_COLLECTMULTIPLEMETRICS.out.versions.first())
     }
 

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -271,6 +271,18 @@ workflow CHIPSEQ {
     ch_versions = ch_versions.mix(FILTER_BAM_BAMTOOLS.out.versions.first().ifEmpty(null))
 
     //
+    // MODULE: Library coverage
+    //
+    ch_preseq_multiqc = Channel.empty()
+    if (!params.skip_preseq) {
+        PRESEQ_LCEXTRAP (
+            MARK_DUPLICATES_PICARD.out.bam
+        )
+        ch_preseq_multiqc = PRESEQ_LCEXTRAP.out.lc_extrap
+        ch_versions       = ch_versions.mix(PRESEQ_LCEXTRAP.out.versions.first())
+    }
+
+    //
     // MODULE: Post alignment QC
     //
     ch_picardcollectmultiplemetrics_multiqc = Channel.empty()
@@ -281,18 +293,6 @@ workflow CHIPSEQ {
         )
         ch_picardcollectmultiplemetrics_multiqc = PICARD_COLLECTMULTIPLEMETRICS.out.metrics
         ch_versions = ch_versions.mix(PICARD_COLLECTMULTIPLEMETRICS.out.versions.first())
-    }
-
-    //
-    // MODULE: Library coverage
-    //
-    ch_preseq_multiqc = Channel.empty()
-    if (!params.skip_preseq) {
-        PRESEQ_LCEXTRAP (
-            FILTER_BAM_BAMTOOLS.out.bam
-        )
-        ch_preseq_multiqc = PRESEQ_LCEXTRAP.out.lc_extrap
-        ch_versions       = ch_versions.mix(PRESEQ_LCEXTRAP.out.versions.first())
     }
 
     //

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -486,7 +486,7 @@ workflow CHIPSEQ {
                         meta.replicates_exist = groups.max { groups.value }.value > 1
                         [ meta, peaks ] }
                 .set { ch_antibody_peaks }
-            // ch_antibody_peaks.dump()
+
             MACS2_CONSENSUS (
                 ch_antibody_peaks
             )
@@ -510,15 +510,11 @@ workflow CHIPSEQ {
                 .map { meta, saf -> [ meta.id, meta, saf ] }
                 .set { ch_ip_saf }
 
-            // ch_ip_saf.dump()
-
             ch_ip_control_bam
                 .map { meta, ip_bam, control_bam -> [ meta.antibody, meta, ip_bam ] }
                 .groupTuple()
                 .map { it -> [ it[0], it[1][0], it[2].flatten().sort() ] }
-                // .dump()
                 .join(ch_ip_saf)
-                .dump()
                 .map {
                     it ->
                         def fmeta = it[1]

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -238,7 +238,7 @@ workflow CHIPSEQ {
     ch_genome_bam
         .map {
             meta, bam ->
-                fmeta = meta.findAll { it.key != 'read_group' }
+                def fmeta = meta.findAll { it.key != 'read_group' }
                 fmeta.id = fmeta.id.split('_')[0..-2].join('_')
                 [ fmeta, bam ] }
         .groupTuple(by: [0])
@@ -521,7 +521,7 @@ workflow CHIPSEQ {
                 .dump()
                 .map {
                     it ->
-                        fmeta = it[1]
+                        def fmeta = it[1]
                         fmeta['id'] = it[3]['id']
                         fmeta['replicates_exist'] = it[3]['replicates_exist']
                         fmeta['multiple_groups']  = it[3]['multiple_groups']

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -438,12 +438,7 @@ workflow CHIPSEQ {
         ch_custompeaks_frip_multiqc  = MULTIQC_CUSTOM_PEAKS.out.frip
         ch_custompeaks_count_multiqc = MULTIQC_CUSTOM_PEAKS.out.count
 
-        if (!params.skip_peak_annotation && !params.skip_peak_qc) {
-            PLOT_MACS2_QC (
-                ch_macs2_peaks.collect{it[1]}
-            )
-            ch_versions = ch_versions.mix(PLOT_MACS2_QC.out.versions)
-
+        if (!params.skip_peak_annotation) {
             HOMER_ANNOTATEPEAKS_MACS2 (
                 ch_macs2_peaks,
                 PREPARE_GENOME.out.fasta,
@@ -451,13 +446,20 @@ workflow CHIPSEQ {
             )
             ch_versions = ch_versions.mix(HOMER_ANNOTATEPEAKS_MACS2.out.versions.first())
 
-            PLOT_HOMER_ANNOTATEPEAKS (
-                HOMER_ANNOTATEPEAKS_MACS2.out.txt.collect{it[1]},
-                ch_peak_annotation_header,
-                "_peaks.annotatePeaks.txt"
-            )
-            ch_plothomerannotatepeaks_multiqc = PLOT_HOMER_ANNOTATEPEAKS.out.tsv
-            ch_versions = ch_versions.mix(PLOT_HOMER_ANNOTATEPEAKS.out.versions)
+            if (!params.skip_peak_qc) {
+                PLOT_MACS2_QC (
+                    ch_macs2_peaks.collect{it[1]}
+                )
+                ch_versions = ch_versions.mix(PLOT_MACS2_QC.out.versions)
+
+                PLOT_HOMER_ANNOTATEPEAKS (
+                    HOMER_ANNOTATEPEAKS_MACS2.out.txt.collect{it[1]},
+                    ch_peak_annotation_header,
+                    "_peaks.annotatePeaks.txt"
+                )
+                ch_plothomerannotatepeaks_multiqc = PLOT_HOMER_ANNOTATEPEAKS.out.tsv
+                ch_versions = ch_versions.mix(PLOT_HOMER_ANNOTATEPEAKS.out.versions)
+            }
         }
 
         //

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -253,10 +253,10 @@ workflow CHIPSEQ {
     //
     // SUBWORKFLOW: Mark duplicates & filter BAM files after merging
     //
-    ch_markduplicates_multiqc = Channel.empty()
     MARK_DUPLICATES_PICARD (
         PICARD_MERGESAMFILES.out.bam
     )
+    ch_versions = ch_versions.mix(MARK_DUPLICATES_PICARD.out.versions)
 
     //
     // SUBWORKFLOW: Fix getting name sorted BAM here for PE/SE


### PR DESCRIPTION
Some fixes:
* Add the ip and control labels to the plotfingerprint.
* Correctly assign `ch_picardcollectmultiplemetrics_multiqc` channel
* Correct pvalue and qvalue arguments for macs2 callpeak
* Fix `skip_peak_annotation` and `skip_peak_qc options`
* Run preseq on the bam coming from markduplicates and not after filtering orphans
* Fix [#282](https://github.com/nf-core/chipseq/issues/282) make `genome.fa` available for IGV
* Skip `preseq` on `test.config`