### PR TITLE
Fix problem if process.stageOutMode = 'move'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated pipeline template to [nf-core/tools 2.7.2](https://github.com/nf-core/tools/releases/tag/2.7.2)
 - [[#317](https://github.com/nf-core/chipseq/issues/317)] Added metro map
+- [[#332](https://github.com/nf-core/chipseq/issues/332)] Fix problem if process.stageOutMode = 'move'
 
 ## [[2.0.0](https://github.com/nf-core/chipseq/releases/tag/2.0.0)] - 2022-10-03
 

--- a/modules/local/bam_remove_orphans.nf
+++ b/modules/local/bam_remove_orphans.nf
@@ -16,6 +16,7 @@ process BAM_REMOVE_ORPHANS {
     output:
     tuple val(meta), path("${prefix}.bam"), emit: bam
     path "versions.yml"                   , emit: versions
+    path(bam)
 
     script: // This script is bundled with the pipeline, in nf-core/chipseq/bin/
     def args = task.ext.args ?: ''


### PR DESCRIPTION
Using `process.stageOutMode = 'move'` will only move files that match the output from a temporary directory to the working directory. Here, it breaks the symlink `${prefix}.bam -> $bam` as only `${prefix}.bam` is moved, creating a dead link.
Defining `path(bam)` as output solves this problem.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
