### PR TITLE
Bump chromap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated pipeline template to [nf-core/tools 2.7.2](https://github.com/nf-core/tools/releases/tag/2.7.2)
 - [[#317](https://github.com/nf-core/chipseq/issues/317)] Added metro map
+- [[#288](https://github.com/nf-core/chipseq/issues/291)] Bump `chromap` version 2 and enable all the steps below chromap again when paired-end data is processed.
 
 ## [[2.0.0](https://github.com/nf-core/chipseq/releases/tag/2.0.0)] - 2022-10-03
 

--- a/bin/bampe_rm_orphan.py
+++ b/bin/bampe_rm_orphan.py
@@ -46,7 +46,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -63,7 +62,6 @@ def makedir(path):
 
 
 def bampe_rm_orphan(BAMIn, BAMOut, onlyFRPairs=False):
-
     ## SETUP DIRECTORY/FILE STRUCTURE
     OutDir = os.path.dirname(BAMOut)
     makedir(OutDir)
@@ -89,7 +87,6 @@ def bampe_rm_orphan(BAMIn, BAMOut, onlyFRPairs=False):
             ## FILTER FOR READS ON SAME CHROMOSOME IN FR ORIENTATION
             if onlyFRPairs:
                 if pair1.tid == pair2.tid:
-
                     ## READ1 FORWARD AND READ2 REVERSE STRAND
                     if not pair1.is_reverse and pair2.is_reverse:
                         if pair1.reference_start <= pair2.reference_start:

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -49,7 +49,6 @@ def check_samplesheet(file_in, file_out):
 
     sample_mapping_dict = {}
     with open(file_in, "r", encoding="utf-8-sig") as fin:
-
         ## Check header
         MIN_COLS = 2
         HEADER = ["sample", "fastq_1", "fastq_2", "antibody", "control"]
@@ -156,7 +155,6 @@ def check_samplesheet(file_in, file_out):
                 + "\n"
             )
             for sample in sorted(sample_mapping_dict.keys()):
-
                 ## Check that multiple runs of the same sample are of the same datatype i.e. single-end / paired-end
                 if not all(x[0] == sample_mapping_dict[sample][0][0] for x in sample_mapping_dict[sample]):
                     print_error(

--- a/bin/igv_files_to_session.py
+++ b/bin/igv_files_to_session.py
@@ -55,7 +55,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -72,7 +71,6 @@ def makedir(path):
 
 
 def igv_files_to_session(XMLOut, ListFile, ReplaceFile, Genome, PathPrefix=""):
-
     makedir(os.path.dirname(XMLOut))
 
     replaceFileDict = {}

--- a/bin/macs2_merged_expand.py
+++ b/bin/macs2_merged_expand.py
@@ -55,7 +55,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -78,7 +77,6 @@ def makedir(path):
 
 
 def macs2_merged_expand(MergedIntervalTxtFile, SampleNameList, OutFile, isNarrow=False, minReplicates=1):
-
     makedir(os.path.dirname(OutFile))
 
     combFreqDict = {}

--- a/modules.json
+++ b/modules.json
@@ -27,12 +27,12 @@
                     },
                     "chromap/chromap": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "git_sha": "d6b7b1f108dab88b0269a4331767c36a1a8da960",
                         "installed_by": ["modules"]
                     },
                     "chromap/index": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "git_sha": "d6b7b1f108dab88b0269a4331767c36a1a8da960",
                         "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {

--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -2,15 +2,15 @@ process CHROMAP_CHROMAP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.2.1 bioconda::samtools=1.15.1" : null)
+    conda "bioconda::chromap=0.2.4 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:963e4fe6a85c548a4018585660aed79780a175d3-0' :
-        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:963e4fe6a85c548a4018585660aed79780a175d3-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0' :
+        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0' }"
 
     input:
     tuple val(meta), path(reads)
-    path fasta
-    path index
+    tuple val(meta2), path(fasta)
+    tuple val(meta2), path(index)
     path barcodes
     path whitelist
     path chr_order

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -20,7 +20,7 @@ tools:
       homepage: https://github.com/haowenz/chromap
       documentation: https://github.com/haowenz/chromap
       tool_dev_url: https://github.com/haowenz/chromap
-      doi: ""
+
       licence: ["GPL v3"]
 input:
   - meta:
@@ -33,6 +33,11 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: |
@@ -86,3 +91,4 @@ output:
 
 authors:
   - "@mahesh-panchal"
+  - "@joseespinosa"

--- a/modules/nf-core/chromap/index/main.nf
+++ b/modules/nf-core/chromap/index/main.nf
@@ -2,17 +2,17 @@ process CHROMAP_INDEX {
     tag "$fasta"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.2.1" : null)
+    conda "bioconda::chromap=0.2.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/chromap:0.2.1--hd03093a_0' :
-        'quay.io/biocontainers/chromap:0.2.1--hd03093a_0' }"
+        'https://depot.galaxyproject.org/singularity/chromap:0.2.4--hd03093a_0' :
+        'quay.io/biocontainers/chromap:0.2.4--hd03093a_0' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "*.index"     , emit: index
-    path "versions.yml", emit: versions
+    tuple val(meta), path ("*.index"), emit: index
+    path "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/chromap/index/meta.yml
+++ b/modules/nf-core/chromap/index/meta.yml
@@ -11,10 +11,15 @@ tools:
       homepage: https://github.com/haowenz/chromap
       documentation: https://github.com/haowenz/chromap
       tool_dev_url: https://github.com/haowenz/chromap
-      doi: ""
+
       licence: ["GPL v3"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: Fasta reference file.
@@ -24,6 +29,11 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - index:
       type: file
       description: Index file of the reference genome
@@ -31,3 +41,4 @@ output:
 
 authors:
   - "@mahesh-panchal"
+  - "@joseespinosa"

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -176,10 +176,10 @@ workflow PREPARE_GENOME {
                 ch_chromap_index = UNTAR_CHROMAP_INDEX ( [ [:], params.chromap_index ] ).untar.map{ it[1] }
                 ch_versions  = ch_versions.mix(UNTAR.out.versions)
             } else {
-                ch_chromap_index = file(params.chromap_index)
+                ch_chromap_index = [ [:], file(params.chromap_index) ]
             }
         } else {
-            ch_chromap_index = CHROMAP_INDEX ( ch_fasta ).index
+            ch_chromap_index = CHROMAP_INDEX ( [ [:], ch_fasta ] ).index
             ch_versions  = ch_versions.mix(CHROMAP_INDEX.out.versions)
         }
     }


### PR DESCRIPTION
Bump version 0.2.4 of `chromap` to fix #291 (paired-end bam files were not correctly formatted by `chromap` and thus, the steps below `chromap` mapping were excluded in this cases, now enable again).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

