### PR TITLE
Remove "enable_conda" from local modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#318](https://github.com/nf-core/chipseq/issues/318)] Update `bowtie2/align` module to fix issue when downloading its singularity image.
 - [[#320](https://github.com/nf-core/chipseq/issues/320)] Fix samplesheet control column in documentation examples.
 - [[#328](https://github.com/nf-core/chipseq/issues/328)] Modify documentation to clarify that is necessary to provide the `--read_length` when `--genome` is set and `--macs_gsize` has not provided.
+- Remove `enable_conda` param from local modules.
+- Fix the path where `chromap` index is stored when `--save_reference` is set.
+- Fix untar of `chromap` index when using `--chromap_index` param.
 
 ### Software dependencies
 

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -655,11 +655,11 @@ params {
             readme      = "${params.igenomes_base}/Saccharomyces_cerevisiae/UCSC/sacCer3/Annotation/README.txt"
             mito_name   = "chrM"
             macs_gsize = [
-                "50"  : "11624332",
-                "75"  : "11693438",
-                "100" : "11777680",
-                "150" : "11783749",
-                "200" : "11825681"
+                "50"  : 11624332,
+                "75"  : 11693438,
+                "100" : 11777680,
+                "150" : 11783749,
+                "200" : 11825681
             ]
         }
         'susScr3' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -258,14 +258,6 @@ if (params.aligner == 'bowtie2') {
 
 if (params.aligner == 'chromap') {
     process {
-        withName: CHROMAP_INDEX {
-            ext.args   = ''
-            publishDir = [
-                path: { "${params.outdir}/genome/${params.aligner}/index" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
         withName: CHROMAP_CHROMAP {
             ext.args   = '-l 2000 --low-mem --SAM'
             ext.prefix = { "${meta.id}.Lb" }

--- a/modules.json
+++ b/modules.json
@@ -172,7 +172,12 @@
                     },
                     "untar": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "git_sha": "cc1f997fab6d8fde5dc0e6e2a310814df5b53ce7",
+                        "installed_by": ["modules"]
+                    },
+                    "untarfiles": {
+                        "branch": "master",
+                        "git_sha": "2498e243c8c30c7125661e62fc777917d8e343b9",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/local/annotate_boolean_peaks.nf
+++ b/modules/local/annotate_boolean_peaks.nf
@@ -2,7 +2,7 @@ process ANNOTATE_BOOLEAN_PEAKS {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
         'ubuntu:20.04' }"

--- a/modules/local/bam_remove_orphans.nf
+++ b/modules/local/bam_remove_orphans.nf
@@ -5,7 +5,7 @@ process BAM_REMOVE_ORPHANS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::pysam=0.19.0 bioconda::samtools=1.15.1" : null)
+    conda "bioconda::pysam=0.19.0 bioconda::samtools=1.15.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:402e865b8f6af2f3e58c6fc8d57127ff0144b2c7-0' :
         'quay.io/biocontainers/mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:402e865b8f6af2f3e58c6fc8d57127ff0144b2c7-0' }"

--- a/modules/local/bamtools_filter.nf
+++ b/modules/local/bamtools_filter.nf
@@ -2,7 +2,7 @@ process BAMTOOLS_FILTER {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::bamtools=2.5.2 bioconda::samtools=1.15.1" : null)
+    conda "bioconda::bamtools=2.5.2 bioconda::samtools=1.15.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:5687a7da26983502d0a8a9a6b05ed727c740ddc4-0' :
         'quay.io/biocontainers/mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:5687a7da26983502d0a8a9a6b05ed727c740ddc4-0' }"

--- a/modules/local/bedtools_genomecov.nf
+++ b/modules/local/bedtools_genomecov.nf
@@ -2,7 +2,7 @@ process BEDTOOLS_GENOMECOV {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
+    conda "bioconda::bedtools=2.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0':
         'quay.io/biocontainers/bedtools:2.30.0--hc088bd4_0' }"

--- a/modules/local/deseq2_qc.nf
+++ b/modules/local/deseq2_qc.nf
@@ -4,7 +4,7 @@ process DESEQ2_QC {
 
     // (Bio)conda packages have intentionally not been pinned to a specific version
     // This was to avoid the pipeline failing due to package conflicts whilst creating the environment when using -profile conda
-    conda (params.enable_conda ? "conda-forge::r-base bioconda::bioconductor-deseq2 bioconda::bioconductor-biocparallel bioconda::bioconductor-tximport bioconda::bioconductor-complexheatmap conda-forge::r-optparse conda-forge::r-ggplot2 conda-forge::r-rcolorbrewer conda-forge::r-pheatmap" : null)
+    conda "conda-forge::r-base bioconda::bioconductor-deseq2 bioconda::bioconductor-biocparallel bioconda::bioconductor-tximport bioconda::bioconductor-complexheatmap conda-forge::r-optparse conda-forge::r-ggplot2 conda-forge::r-rcolorbrewer conda-forge::r-pheatmap"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0' :
         'quay.io/biocontainers/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0' }"

--- a/modules/local/frip_score.nf
+++ b/modules/local/frip_score.nf
@@ -2,7 +2,7 @@ process FRIP_SCORE {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0 bioconda::samtools=1.15.1" : null)
+    conda "bioconda::bedtools=2.30.0 bioconda::samtools=1.15.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:3127fcae6b6bdaf8181e21a26ae61231030a9fcb-0':
         'quay.io/biocontainers/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:3127fcae6b6bdaf8181e21a26ae61231030a9fcb-0' }"

--- a/modules/local/genome_blacklist_regions.nf
+++ b/modules/local/genome_blacklist_regions.nf
@@ -4,7 +4,7 @@
 process GENOME_BLACKLIST_REGIONS {
     tag "$sizes"
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
+    conda "bioconda::bedtools=2.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0':
         'quay.io/biocontainers/bedtools:2.30.0--hc088bd4_0' }"

--- a/modules/local/gtf2bed.nf
+++ b/modules/local/gtf2bed.nf
@@ -2,7 +2,7 @@ process GTF2BED {
     tag "$gtf"
     label 'process_low'
 
-    conda (params.enable_conda ? "conda-forge::perl=5.26.2" : null)
+    conda "conda-forge::perl=5.26.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/perl:5.26.2':
         'quay.io/biocontainers/perl:5.26.2' }"

--- a/modules/local/igv.nf
+++ b/modules/local/igv.nf
@@ -3,7 +3,7 @@
  */
 process IGV {
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    conda "conda-forge::python=3.8.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.8.3':
         'quay.io/biocontainers/python:3.8.3' }"

--- a/modules/local/macs2_consensus.nf
+++ b/modules/local/macs2_consensus.nf
@@ -5,7 +5,7 @@ process MACS2_CONSENSUS {
     tag "$meta.id"
     label 'process_long'
 
-    conda (params.enable_conda ? "conda-forge::biopython conda-forge::r-optparse=1.7.1 conda-forge::r-upsetr=1.4.0 bioconda::bedtools=2.30.0" : null)
+    conda "conda-forge::biopython conda-forge::r-optparse=1.7.1 conda-forge::r-upsetr=1.4.0 bioconda::bedtools=2.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-2f48cc59b03027e31ead6d383fe1b8057785dd24:5d182f583f4696f4c4d9f3be93052811b383341f-0':
         'quay.io/biocontainers/mulled-v2-2f48cc59b03027e31ead6d383fe1b8057785dd24:5d182f583f4696f4c4d9f3be93052811b383341f-0' }"

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::multiqc=1.13a" : null)
+    conda "bioconda::multiqc=1.13a"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1':
         'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"

--- a/modules/local/multiqc_custom_peaks.nf
+++ b/modules/local/multiqc_custom_peaks.nf
@@ -1,6 +1,6 @@
 process MULTIQC_CUSTOM_PEAKS {
     tag "$meta.id"
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
         'ubuntu:20.04' }"

--- a/modules/local/multiqc_custom_phantompeakqualtools.nf
+++ b/modules/local/multiqc_custom_phantompeakqualtools.nf
@@ -1,6 +1,6 @@
 process MULTIQC_CUSTOM_PHANTOMPEAKQUALTOOLS {
     tag "$meta.id"
-    conda (params.enable_conda ? "conda-forge::r-base=3.5.1" : null)
+    conda "conda-forge::r-base=3.5.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/r-base:3.5.1':
         'quay.io/biocontainers/r-base:3.5.1' }"

--- a/modules/local/plot_homer_annotatepeaks.nf
+++ b/modules/local/plot_homer_annotatepeaks.nf
@@ -1,7 +1,7 @@
 process PLOT_HOMER_ANNOTATEPEAKS {
     label 'process_medium'
 
-    conda (params.enable_conda ? "conda-forge::r-base=4.0.3 conda-forge::r-reshape2=1.4.4 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.3 conda-forge::r-scales=1.1.1 conda-forge::r-viridis=0.5.1 conda-forge::r-tidyverse=1.3.0 bioconda::bioconductor-biostrings=2.58.0 bioconda::bioconductor-complexheatmap=2.6.2" : null)
+    conda "conda-forge::r-base=4.0.3 conda-forge::r-reshape2=1.4.4 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.3 conda-forge::r-scales=1.1.1 conda-forge::r-viridis=0.5.1 conda-forge::r-tidyverse=1.3.0 bioconda::bioconductor-biostrings=2.58.0 bioconda::bioconductor-complexheatmap=2.6.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0':
         'quay.io/biocontainers/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0' }"

--- a/modules/local/plot_macs2_qc.nf
+++ b/modules/local/plot_macs2_qc.nf
@@ -1,7 +1,7 @@
 process PLOT_MACS2_QC {
     label 'process_medium'
 
-    conda (params.enable_conda ? "conda-forge::r-base=4.0.3 conda-forge::r-reshape2=1.4.4 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.3 conda-forge::r-scales=1.1.1 conda-forge::r-viridis=0.5.1 conda-forge::r-tidyverse=1.3.0 bioconda::bioconductor-biostrings=2.58.0 bioconda::bioconductor-complexheatmap=2.6.2" : null)
+    conda "conda-forge::r-base=4.0.3 conda-forge::r-reshape2=1.4.4 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.3 conda-forge::r-scales=1.1.1 conda-forge::r-viridis=0.5.1 conda-forge::r-tidyverse=1.3.0 bioconda::bioconductor-biostrings=2.58.0 bioconda::bioconductor-complexheatmap=2.6.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0':
         'quay.io/biocontainers/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0' }"

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -3,7 +3,7 @@ process STAR_ALIGN {
     label 'process_high'
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    conda "bioconda::star=2.6.1d"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/star:2.6.1d--0' :
         'quay.io/biocontainers/star:2.6.1d--0' }"

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -10,7 +10,7 @@ process STAR_ALIGN {
 
     input:
     tuple val(meta) , path(reads)
-    tuple val(meta2), path(index)
+    path  index
     val seq_center
 
     output:

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -9,8 +9,8 @@ process STAR_ALIGN {
         'quay.io/biocontainers/star:2.6.1d--0' }"
 
     input:
-    tuple val(meta), path(reads)
-    path  index
+    tuple val(meta) , path(reads)
+    tuple val(meta2), path(index)
     val seq_center
 
     output:

--- a/modules/local/star_genomegenerate.nf
+++ b/modules/local/star_genomegenerate.nf
@@ -3,7 +3,7 @@ process STAR_GENOMEGENERATE {
     label 'process_high'
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d bioconda::samtools=1.10 conda-forge::gawk=5.1.0" : null)
+    conda "bioconda::star=2.6.1d bioconda::samtools=1.10 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0' :
         'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0' }"

--- a/modules/nf-core/untarfiles/meta.yml
+++ b/modules/nf-core/untarfiles/meta.yml
@@ -1,0 +1,41 @@
+name: untarfiles
+description: Extract files.
+keywords:
+  - untar
+  - uncompress
+tools:
+  - untar:
+      description: |
+        Extract tar.gz files.
+      documentation: https://www.gnu.org/software/tar/manual/
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - archive:
+      type: file
+      description: File to be untar
+      pattern: "*.{tar}.{gz}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - files:
+      type: list
+      description: A list containing references to individual archive files
+      pattern: "*/**"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@matthdsm"
+  - "@jfy133"
+  - "@pinin4fjords"

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -12,9 +12,9 @@ include {
 include {
     UNTAR as UNTAR_BWA_INDEX
     UNTAR as UNTAR_BOWTIE2_INDEX
-    UNTAR as UNTAR_CHROMAP_INDEX
     UNTAR as UNTAR_STAR_INDEX    } from '../../modules/nf-core/untar/main'
 
+include { UNTARFILES           } from '../../modules/nf-core/untarfiles/main'
 include { GFFREAD              } from '../../modules/nf-core/gffread/main'
 include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
 include { BWA_INDEX            } from '../../modules/nf-core/bwa/index/main'
@@ -138,7 +138,7 @@ workflow PREPARE_GENOME {
     if (prepare_tool_index == 'bwa') {
         if (params.bwa_index) {
             if (params.bwa_index.endsWith('.tar.gz')) {
-                ch_bwa_index = UNTAR_BWA_INDEX ( [ [:], params.bwa_index ] ).untar.map{ it[1] }
+                ch_bwa_index = UNTAR_BWA_INDEX ( [ [:], params.bwa_index ] ).untar
                 ch_versions  = ch_versions.mix(UNTAR_BWA_INDEX.out.versions)
             } else {
                 ch_bwa_index = file(params.bwa_index)
@@ -174,8 +174,8 @@ workflow PREPARE_GENOME {
     if (prepare_tool_index == 'chromap') {
         if (params.chromap_index) {
             if (params.chromap_index.endsWith('.tar.gz')) {
-                ch_chromap_index = UNTAR_CHROMAP_INDEX ( [ [:], params.chromap_index ] ).untar.map{ it[1] }
-                ch_versions  = ch_versions.mix(UNTAR.out.versions)
+                ch_chromap_index = UNTARFILES ( [ [:], params.chromap_index ] ).files
+                ch_versions  = ch_versions.mix(UNTARFILES.out.versions)
             } else {
                 ch_chromap_index = [ [:], file(params.chromap_index) ]
             }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -192,7 +192,7 @@ workflow PREPARE_GENOME {
     if (prepare_tool_index == 'star') {
         if (params.star_index) {
             if (params.star_index.endsWith('.tar.gz')) {
-                ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar
+                ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar.map{ it[1] }
                 ch_versions   = ch_versions.mix(UNTAR_STAR_INDEX.out.versions)
             } else {
                 ch_star_index = file(params.star_index)

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -192,7 +192,7 @@ workflow PREPARE_GENOME {
     if (prepare_tool_index == 'star') {
         if (params.star_index) {
             if (params.star_index.endsWith('.tar.gz')) {
-                ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar.map{ it[1] }
+                ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar
                 ch_versions   = ch_versions.mix(UNTAR_STAR_INDEX.out.versions)
             } else {
                 ch_star_index = file(params.star_index)


### PR DESCRIPTION
* Removes `enable_conda` from the local modules.
* Updates `untar` module.
* Uses `untarfiles` for uncompressing the chromap index which is a single file (might not be working before)
* Fixes path where `chromap` index is stored when using `-s-ave_reference`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
