### PR TITLE
Fix publishDir paths in modules.config

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -44,12 +44,12 @@ module_order:
       name: "MERGED LIB: SAMTools (unfiltered)"
       info: "This section of the report shows SAMTools results after merging libraries and before filtering."
       path_filters:
-        - "./alignment/mergedLibrary/unfiltered/*.mLb.mkD.sorted.bam*"
+        - "./alignment/merged_library/unfiltered/*.mLb.mkD.sorted.bam*"
   - picard:
       name: "MERGED LIB: Picard (unfiltered)"
       info: "This section of the report shows picard results after merging libraries and before filtering."
       path_filters:
-        - "./alignment/mergedLibrary/unfiltered/picard_metrics/*"
+        - "./alignment/merged_library/unfiltered/picard_metrics/*"
   - preseq:
       name: "MERGED LIB: Preseq (unfiltered)"
       info: "This section of the report shows Preseq results after merging libraries and before filtering."
@@ -57,12 +57,12 @@ module_order:
       name: "MERGED LIB: SAMTools (filtered)"
       info: "This section of the report shows SAMTools results after merging libraries and after filtering."
       path_filters:
-        - "./alignment/mergedLibrary/filtered/*.mLb.clN.sorted.bam*"
+        - "./alignment/merged_library/filtered/*.mLb.clN.sorted.bam*"
   - picard:
       name: "MERGED LIB: Picard (filtered)"
       info: "This section of the report shows picard results after merging libraries and after filtering."
       path_filters:
-        - "./alignment/mergedLibrary/filtered/picard_metrics/*"
+        - "./alignment/merged_library/filtered/picard_metrics/*"
   - deeptools:
       name: "MERGED LIB: deepTools"
       anchor: "mlib_deeptools"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -329,12 +329,12 @@ process {
         ext.prefix = { "${meta.id}.mLb.mkD.sorted" }
         publishDir = [
             [
-                path: { "${params.outdir}/${params.aligner}/mergedLibrary/picard_metrics" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/picard_metrics" },
                 mode: params.publish_dir_mode,
                 pattern: '*.metrics.txt'
             ],
             [
-                path: { "${params.outdir}/${params.aligner}/mergedLibrary" },
+                path: { "${params.outdir}/${params.aligner}/merged_library" },
                 mode: params.publish_dir_mode,
                 pattern: '*.bam',
                 enabled: params.save_align_intermeds
@@ -344,7 +344,7 @@ process {
 
     withName: '.*:BAM_MARKDUPLICATES_PICARD:SAMTOOLS_INDEX' {
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/mergedLibrary" },
+            path: { "${params.outdir}/${params.aligner}/merged_library" },
             mode: params.publish_dir_mode,
             pattern: '*.{bai,csi}',
             enabled: params.save_align_intermeds
@@ -354,7 +354,7 @@ process {
     withName: '.*:BAM_MARKDUPLICATES_PICARD:BAM_STATS_SAMTOOLS:.*' {
         ext.prefix = { "${meta.id}.mLb.mkD.sorted.bam" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/mergedLibrary/samtools_stats" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/samtools_stats" },
             mode: params.publish_dir_mode,
             pattern: '*.{stats,flagstat,idxstats}'
         ]
@@ -392,7 +392,7 @@ process {
         ext.args   = '-n'
         ext.prefix = { "${meta.id}.mLb.flT.name_sorted" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/mergedLibrary" },
+            path: { "${params.outdir}/${params.aligner}/merged_library" },
             mode: params.publish_dir_mode,
             pattern: '*.bam',
             enabled: params.save_align_intermeds
@@ -559,7 +559,7 @@ process {
         publishDir = [
             path: { [
                 "${params.outdir}/${params.aligner}/merged_library/macs2",
-                params.narrow_peak? '/narrowPeak' : '/broadPeak'
+                params.narrow_peak? '/narrow_peak' : '/broad_peak'
             ].join('') },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -569,14 +569,14 @@ process {
     withName: 'FRIP_SCORE' {
         ext.args   = '-bed -c -f 0.20'
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/qc" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
             enabled: false
         ]
     }
 
     withName: 'MULTIQC_CUSTOM_PEAKS' {
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak} ? '/narrowPeak' : '/broadPeak'}/qc" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -589,7 +589,7 @@ if (!params.skip_peak_annotation) {
             ext.args   = '-gid'
             ext.prefix = { "${meta.id}_peaks" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak' }" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -611,7 +611,7 @@ if (!params.skip_peak_annotation) {
                 ext.args   = '-o ./'
                 ext.prefix = 'macs2_annotatePeaks'
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/qc" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -626,7 +626,7 @@ if (!params.skip_consensus_peaks) {
             ext.when   = { meta.multiple_groups || meta.replicates_exist }
             ext.prefix = { "${meta.id}.consensus_peaks" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/consensus/${meta.id}" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/${meta.id}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -636,7 +636,7 @@ if (!params.skip_consensus_peaks) {
             ext.args   = '-F SAF -O --fracOverlap 0.2'
             ext.prefix = { "${meta.id}.consensus_peaks" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak? '/narrowPeak' : '/broadPeak'}/consensus/${meta.id}" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/${meta.id}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -649,7 +649,7 @@ if (!params.skip_consensus_peaks) {
                 ext.args   = '-gid'
                 ext.prefix = { "${meta.id}.consensus_peaks" }
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/consensus/${meta.id}" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/${meta.id}" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -658,7 +658,7 @@ if (!params.skip_consensus_peaks) {
             withName: 'ANNOTATE_BOOLEAN_PEAKS' {
                 ext.prefix = { "${meta.id}.consensus_peaks" }
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/consensus/${meta.id}" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/${meta.id}" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -678,7 +678,7 @@ if (!params.skip_consensus_peaks) {
                 ].join(' ').trim()
                 ext.prefix = { "${meta.id}.consensus_peaks" }
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}/consensus/${meta.id}/deseq2" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/${meta.id}/deseq2" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -692,7 +692,7 @@ if (!params.skip_igv) {
         withName: 'IGV' {
             publishDir = [
                 [
-                        path: { "${params.outdir}/igv/${params.narrow_peak? '/narrowPeak' : '/broadPeak' }" },
+                        path: { "${params.outdir}/igv/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                         mode: params.publish_dir_mode,
                         pattern: '*.{txt,xml}'
                 ],
@@ -711,7 +711,7 @@ if (!params.skip_multiqc) {
         withName: 'MULTIQC' {
             ext.args   = params.multiqc_title ? "--title \"$params.multiqc_title\"" : ''
             publishDir = [
-                path: { "${params.outdir}/multiqc/${params.narrow_peak ? '/narrowPeak' : '/broadPeak'}" },
+                path: { "${params.outdir}/multiqc/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]

--- a/modules/local/igv.nf
+++ b/modules/local/igv.nf
@@ -12,9 +12,9 @@ process IGV {
     val aligner_dir
     val peak_dir
     path fasta
-    path ("${aligner_dir}/mergedLibrary/bigwig/*")
-    path ("${aligner_dir}/mergedLibrary/macs2/${peak_dir}/*")
-    path ("${aligner_dir}/mergedLibrary/macs2/${peak_dir}/consensus/*")
+    path ("${aligner_dir}/merged_library/bigwig/*")
+    path ("${aligner_dir}/merged_library/macs2/${peak_dir}/*")
+    path ("${aligner_dir}/merged_library/macs2/${peak_dir}/consensus/*")
     path ("mappings/*")
 
     output:
@@ -27,7 +27,7 @@ process IGV {
     task.ext.when == null || task.ext.when
 
     script: // scripts are bundled with the pipeline in nf-core/chipseq/bin/
-    def consensus_dir = "${aligner_dir}/mergedLibrary/macs2/${peak_dir}/consensus/*"
+    def consensus_dir = "${aligner_dir}/merged_library/macs2/${peak_dir}/consensus/*"
     """
     find * -type l -name "*.bigWig" -exec echo -e ""{}"\\t0,0,178" \\; > bigwig.igv.txt
     find * -type l -name "*Peak" -exec echo -e ""{}"\\t0,0,178" \\; > peaks.igv.txt

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -22,15 +22,15 @@ process MULTIQC {
     path ('alignment/library/*')
     path ('alignment/library/*')
 
-    path ('alignment/mergedLibrary/unfiltered/*')
-    path ('alignment/mergedLibrary/unfiltered/*')
-    path ('alignment/mergedLibrary/unfiltered/*')
-    path ('alignment/mergedLibrary/unfiltered/picard_metrics/*')
+    path ('alignment/merged_library/unfiltered/*')
+    path ('alignment/merged_library/unfiltered/*')
+    path ('alignment/merged_library/unfiltered/*')
+    path ('alignment/merged_library/unfiltered/picard_metrics/*')
 
-    path ('alignment/mergedLibrary/filtered/*')
-    path ('alignment/mergedLibrary/filtered/*')
-    path ('alignment/mergedLibrary/filtered/*')
-    path ('alignment/mergedLibrary/filtered/picard_metrics/*')
+    path ('alignment/merged_library/filtered/*')
+    path ('alignment/merged_library/filtered/*')
+    path ('alignment/merged_library/filtered/*')
+    path ('alignment/merged_library/filtered/picard_metrics/*')
 
     path ('preseq/*')
 

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -692,7 +692,7 @@ workflow CHIPSEQ {
     if (!params.skip_igv) {
         IGV (
             params.aligner,
-            params.narrow_peak ? 'narrowPeak' : 'broadPeak',
+            params.narrow_peak ? 'narrow_peak' : 'broad_peak',
             PREPARE_GENOME.out.fasta,
             UCSC_BEDGRAPHTOBIGWIG.out.bigwig.collect{it[1]}.ifEmpty([]),
             ch_macs2_peaks.collect{it[1]}.ifEmpty([]),


### PR DESCRIPTION
**This PR:**

Fixes the publishDir paths for `../merged_library/` and `../broad_peak/` or `../narrow_peak/`. Currently, the pipeline was creating three different directories for each peak type.

<!--
# nf-core/chipseq pull request

Many thanks for contributing to nf-core/chipseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/chipseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
