### PR TITLE
Fix stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#343](https://github.com/nf-core/chipseq/issues/343)] - Provide replicate information explicitly in samplesheet.
 - Updated pipeline template to [nf-core/tools 2.10](https://github.com/nf-core/tools/releases/tag/2.10).
 - [[#367](https://github.com/nf-core/chipseq/issues/367)] - Get rid of `CheckIfExists` for params paths.
+- [[#370](https://github.com/nf-core/chipseq/issues/370)] - Fix stack overflow exceptions in phantompeakqualtools ([see here](https://github.com/kundajelab/phantompeakqualtools/issues/3)).
 
 ### Software dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -418,6 +418,7 @@ process {
     }
 
     withName: 'PHANTOMPEAKQUALTOOLS' {
+        ext.args   = { "--max-ppsize=500000" }
         ext.args2  = { "-p=$task.cpus" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/merged_library/phantompeakqualtools" },


### PR DESCRIPTION
This PR addresses #370. In summary, PHANTOMPEAKQUALTOOLS throws a stack overflow exception on certain types of input data. [This issue](https://github.com/kundajelab/phantompeakqualtools/issues/3) suggests a fix by increasing the default `--max-ppsize`. This is already implemented in MULTIQC_CUSTOM_PHANTOMPEAKQUALTOOLS. I just added the same parameter to PHANTOMPEAKQUALTOOLS via the modules.conf. This allows the pipeline to run successfully on our data. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/chipseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/chipseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
