### PR TITLE
Trimgalore nextseq correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [[#429](https://github.com/nf-core/chipseq/issues/429)] - Correcting the nextseq trimming setting in conf/modules.config
+
 ### Parameters
 
 | Old parameter | New parameter |

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -135,7 +135,7 @@ if (!params.skip_trimming) {
             ext.args   = {
                 [
                     '--fastqc',
-                    params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : '',
+                    params.trim_nextseq > 0 ? "--nextseq-trim ${params.trim_nextseq}" : '',
                     params.clip_r1 > 0 ? "--clip_r1 ${params.clip_r1}" : '',
                     params.clip_r2 > 0 ? "--clip_r2 ${params.clip_r2}" : '',
                     params.three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${params.three_prime_clip_r1}" : '',


### PR DESCRIPTION
Closes #429 

This changes the parameter `-nextseq`, which is set when the user specifies an integer for the `trim_nextseq` parameter, to `nextseq-trim`. See the cutadapt docs

https://cutadapt.readthedocs.io/en/stable/guide.html#nextseq-trim