### PR TITLE
Fix multiqc skip

### DIFF
--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -524,6 +524,8 @@ workflow CHIPSEQ {
     //
     // MODULE: MultiQC
     //
+    ch_multiqc_report = Channel.empty()
+
     if (!params.skip_multiqc) {
         ch_multiqc_config        = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
         ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath( params.multiqc_config ): Channel.empty()
@@ -578,7 +580,8 @@ workflow CHIPSEQ {
         ch_multiqc_report = MULTIQC.out.report
     }
 
-    emit:multiqc_report = MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
+    emit:
+    multiqc_report = ch_multiqc_report.toList() // channel: /path/to/multiqc_report.html
     versions       = ch_versions                 // channel: [ path(versions.yml) ]
 
 }

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -581,7 +581,7 @@ workflow CHIPSEQ {
     }
 
     emit:
-    multiqc_report = ch_multiqc_report.toList() // channel: /path/to/multiqc_report.html
+    multiqc_report = ch_multiqc_report.toList()  // channel: /path/to/multiqc_report.html
     versions       = ch_versions                 // channel: [ path(versions.yml) ]
 
 }


### PR DESCRIPTION
When the `skip_multiqc` parameter is used, the pipeline attempts to generate output from a non-existent channel, resulting in an error. This PR resolves the issue by introducing an empty channel, `ch_multiqc_report`, to ensure the output is handled without errors.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/chipseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/chipseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
