### PR TITLE
Fixes parametrization of SUBREAD_FEATURECOUNTS depending on meta.single_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#432](https://github.com/nf-core/chipseq/issues/432)] - Fix `GFFREAD` call to have the two expected input channels.
 - [[PR #444](https://github.com/nf-core/chipseq/pull/444)] - Add empty map to ch_gff so that when provided by the user `GFFREAD` works.
 - Updated pipeline template to [nf-core/tools 3.2.0](https://github.com/nf-core/tools/releases/tag/3.2.0).
-- [[#451](https://github.com/nf-core/chipseq/issues/451)] - Pass `map.single_read` to `SUBREAD_FEATURECOUNTS` as to correctly set parameter `-p`. 
+- [[#451](https://github.com/nf-core/chipseq/issues/451)] - Pass `map.single_read` to `SUBREAD_FEATURECOUNTS` as to correctly set parameter `-p`.
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [[#428](https://github.com/nf-core/chipseq/issues/428)] - Bump MultiQC version to 1.25.1
+- [[#428](https://github.com/nf-core/chipseq/issues/428)] - Bump MultiQC version to `1.25.1`.
 - [[PR #434](https://github.com/nf-core/chipseq/pull/434)] - Prevent pipeline fails from erroneous param validation when igenomes is used.
 - [[#432](https://github.com/nf-core/chipseq/issues/432)] - Fix `GFFREAD` call to have the two expected input channels.
 - [[PR #444](https://github.com/nf-core/chipseq/pull/444)] - Add empty map to ch_gff so that when provided by the user `GFFREAD` works.
-- Updated pipeline template to [nf-core/tools 3.2.0](https://github.com/nf-core/tools/releases/tag/3.2.0)
+- Updated pipeline template to [nf-core/tools 3.2.0](https://github.com/nf-core/tools/releases/tag/3.2.0).
+- [[#451](https://github.com/nf-core/chipseq/issues/451)] - Pass `map.single_read` to `SUBREAD_FEATURECOUNTS` as to correctly set parameter `-p`. 
 
 ### Parameters
 

--- a/subworkflows/local/bed_consensus_quantify_qc_bedtools_featurecounts_deseq2.nf
+++ b/subworkflows/local/bed_consensus_quantify_qc_bedtools_featurecounts_deseq2.nf
@@ -90,8 +90,8 @@ workflow BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 {
         }
         .join(ch_bams)
         .map {
-            antibody, meta, saf, bams ->
-                [ meta, bams.flatten().sort(), saf ]
+            antibody, meta, saf, bams, meta_single_end ->
+                [ meta + meta_single_end, bams.flatten().sort(), saf ]
         }
         .set { ch_bam_saf }
 

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -130,7 +130,6 @@ workflow CHIPSEQ {
     )
     ch_versions = ch_versions.mix(FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.versions)
 
-
     //
     // SUBWORKFLOW: Alignment with BWA & BAM QC
     //
@@ -474,9 +473,14 @@ workflow CHIPSEQ {
         ch_ip_control_bam
             .map {
                 meta, ip_bam, control_bam ->
-                    [ meta.antibody, ip_bam ]
+                    [ meta.antibody, meta.single_end, ip_bam ]
             }
             .groupTuple()
+            .map {
+                antibody, single_end, ip_bams ->
+                    def single_end_map = single_end.unique().size() == 1 ? [single_end: single_end[0]] : false
+                    [ antibody, ip_bams, single_end_map ]
+            }
             .set { ch_antibody_bams }
 
         BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 (

--- a/workflows/chipseq.nf
+++ b/workflows/chipseq.nf
@@ -469,7 +469,7 @@ workflow CHIPSEQ {
     ch_deseq2_pca_multiqc        = Channel.empty()
     ch_deseq2_clustering_multiqc = Channel.empty()
     if (!params.skip_consensus_peaks) {
-        // Create channels: [ antibody, [ ip_bams ] ]
+        // Create channels: [ antibody, [ ip_bams ], single_end_map ]
         ch_ip_control_bam
             .map {
                 meta, ip_bam, control_bam ->


### PR DESCRIPTION
The `meta.single_read` was not provided to `SUBREAD_FEATURECOUNTS` and thus, the `-p` argument was always set. This PR fixes this and closes #451 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
