### PR TITLE
Use `--skip_preseq` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #514](https://github.com/nf-core/chipseq/pull/514)] - Updated pipeline template to [nf-core/tools
   4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2).
 - [[#519] (https://github.com/nf-core/chipseq/issues/519)] - Changed merged libraries suffix to `.mLb.`.
-- [[#456] (https://github.com/nf-core/chipseq/issues/456)] - - Use `--skip_preseq` by default.
+- [[#456] (https://github.com/nf-core/chipseq/issues/456)] - Use `--skip_preseq` by default.
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#484](https://github.com/nf-core/chipseq/issues/484)] - Bulk, updated of modules and subworkflows.
 - [[#489](https://github.com/nf-core/chipseq/issues/489)] - Replace deprecated `CUSTOM_GETCHROMSIZES` with `SAMTOOLS_FAIDX`.
 - [[PR #493](https://github.com/nf-core/chipseq/pull/493)] - Follow up to #487.
-- [[PR #493](https://github.com/nf-core/chipseq/pull/493)] - Follow up to #487.
 - [[#492](https://github.com/nf-core/chipseq/issues/492), [#417](https://github.com/nf-core/chipseq/issues/417)] - Refactor local modules to nf-core standard.
 - [[#416](https://github.com/nf-core/chipseq/issues/416)] - Moved the `KHMER_UNIQUEKMERS` logic to prepare_genome
 - [[#440](https://github.com/nf-core/chipseq/issues/440), [#510](https://github.com/nf-core/chipseq/issues/510)] - Fix
@@ -30,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #514](https://github.com/nf-core/chipseq/pull/514)] - Updated pipeline template to [nf-core/tools
   4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2).
 - [[#519] (https://github.com/nf-core/chipseq/issues/519)] - Changed merged libraries suffix to `.mLb.`.
+- [[#456] (https://github.com/nf-core/chipseq/issues/456)] - - Use `--skip_preseq` by default.
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ You can find numerous talks on the [nf-core events page](https://nf-co.re/events
       - reads that map to different chromosomes ([`Pysam`](http://pysam.readthedocs.io/en/latest/installation.html); _paired-end only_)
       - reads that arent in FR orientation ([`Pysam`](http://pysam.readthedocs.io/en/latest/installation.html); _paired-end only_)
       - reads where only one read of the pair fails the above criteria ([`Pysam`](http://pysam.readthedocs.io/en/latest/installation.html); _paired-end only_)
-   3. Alignment-level QC and estimation of library complexity ([`picard`](https://broadinstitute.github.io/picard/), [`Preseq`](http://smithlabresearch.org/software/preseq/))
+   3. Alignment-level QC and estimation of library complexity:
+      -  [`picard`](https://broadinstitute.github.io/picard/) 
+      - [`Preseq`](http://smithlabresearch.org/software/preseq/) (skipped by default)
    4. Create normalised bigWig files scaled to 1 million mapped reads ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedGraphToBigWig`](http://hgdownload.soe.ucsc.edu/admin/exe/))
    5. Generate gene-body meta-profile from bigWig files ([`deepTools`](https://deeptools.readthedocs.io/en/develop/content/tools/plotProfile.html))
    6. Calculate genome-wide IP enrichment relative to control ([`deepTools`](https://deeptools.readthedocs.io/en/develop/content/tools/plotFingerprint.html))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can find numerous talks on the [nf-core events page](https://nf-co.re/events
       - reads that arent in FR orientation ([`Pysam`](http://pysam.readthedocs.io/en/latest/installation.html); _paired-end only_)
       - reads where only one read of the pair fails the above criteria ([`Pysam`](http://pysam.readthedocs.io/en/latest/installation.html); _paired-end only_)
    3. Alignment-level QC and estimation of library complexity:
-      -  [`picard`](https://broadinstitute.github.io/picard/) 
+      - [`picard`](https://broadinstitute.github.io/picard/)
       - [`Preseq`](http://smithlabresearch.org/software/preseq/) (skipped by default)
    4. Create normalised bigWig files scaled to 1 million mapped reads ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedGraphToBigWig`](http://hgdownload.soe.ucsc.edu/admin/exe/))
    5. Generate gene-body meta-profile from bigWig files ([`deepTools`](https://deeptools.readthedocs.io/en/develop/content/tools/plotProfile.html))

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,7 +57,7 @@ params {
     skip_qc                    = false
     skip_fastqc                = false
     skip_picard_metrics        = false
-    skip_preseq                = false
+    skip_preseq                = true
     skip_plot_profile          = false
     skip_plot_fingerprint      = false
     skip_spp                   = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -360,7 +360,7 @@
                     "type": "boolean",
                     "description": "Skip Preseq.",
                     "fa_icon": "fas fa-fast-forward",
-                    "default": false
+                    "default": true
                 },
                 "deseq2_vst": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -359,7 +359,8 @@
                 "skip_preseq": {
                     "type": "boolean",
                     "description": "Skip Preseq.",
-                    "fa_icon": "fas fa-fast-forward"
+                    "fa_icon": "fas fa-fast-forward",
+                    "default": false
                 },
                 "deseq2_vst": {
                     "type": "boolean",


### PR DESCRIPTION
Make `skip_preseq` the default option.

Closes #456

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
